### PR TITLE
No access token caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For both `@planship/axios` and `@planship/fetch`, import and instantiate the `Pl
 
 ```js
 import { Planship } from '@planship/axios'
-# or
+// or
 import { Planship } from '@planship/fetch'
 
 const planship = new Planship(
@@ -30,10 +30,10 @@ const planship = new Planship(
     'GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX'  // Planship API client secret
 )
 
-# List product plans
+// List product plans
 const plans = await planship.listPlans()
 
-# Create a customer with a given email, and subscribe them to a plan
+// Create a customer with a given email, and subscribe them to a plan
 customer = await planship.createCustomer(
     {
         'email': 'vader@empire.gov'
@@ -46,12 +46,12 @@ customer = await planship.createCustomer(
     return customer
 })
 
-# Retrieve customer entitlements
+// Retrieve customer entitlements
 const customerEntitlements = await planship.getEntitlement(
     customer.id     // Customer ID
 )
 
-# Report usage for a customer
+// Report usage for a customer
 await planship.reportUsage(
     customer.id,    // Customer ID
     1,

--- a/packages/axios/README.md
+++ b/packages/axios/README.md
@@ -25,10 +25,10 @@ const planship = new Planship(
     'GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX'  // Planship API client secret
 )
 
-# List product plans
+// List product plans
 const plans = await planship.listPlans()
 
-# Create a customer with a given email, and subscribe them to a plan
+// Create a customer with a given email, and subscribe them to a plan
 customer = await planship.createCustomer(
     {
         'email': 'vader@empire.gov'
@@ -41,12 +41,12 @@ customer = await planship.createCustomer(
     return customer
 })
 
-# Retrieve customer entitlements
+// Retrieve customer entitlements
 const customerEntitlements = await planship.getEntitlement(
     customer.id     // Customer ID
 )
 
-# Report usage for the customer
+// Report usage for the customer
 await planship.reportUsage(
     customer.id,    // Customer ID
     1,

--- a/packages/axios/docs/README.md
+++ b/packages/axios/docs/README.md
@@ -24,10 +24,10 @@ const planship = new Planship(
     'GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX'  // Planship API client secret
 )
 
-# List product plans
+// List product plans
 const plans = await planship.listPlans()
 
-# Create a customer with a given email, and subscribe them to a plan
+// Create a customer with a given email, and subscribe them to a plan
 customer = await planship.createCustomer(
     {
         'email': 'vader@empire.gov'
@@ -40,12 +40,12 @@ customer = await planship.createCustomer(
     return customer
 })
 
-# Retrieve customer entitlements
+// Retrieve customer entitlements
 const customerEntitlements = await planship.getEntitlement(
     customer.id     // Customer ID
 )
 
-# Report usage for the customer
+// Report usage for the customer
 await planship.reportUsage(
     customer.id,    // Customer ID
     1,
@@ -88,4 +88,4 @@ const accessToken = await planship.getAccessToken()
 
 ## Complete SDK reference
 
-A complete reference for the `Planship` class and all related response models can be found [here](classes/Planship.md).
+A complete reference for the `Planship` class and all related response models can be found [here](docs/classes/Planship.md).

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/axios",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "dist/index.js",
   "author": "<pawel@planship.io>",
   "license": "MIT",

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -27,10 +27,10 @@ const planship = new Planship(
     'GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX'  // Planship API client secret
 )
 
-# List product plans
+// List product plans
 const plans = await planship.listPlans()
 
-# Create a customer with a given email, and subscribe them to a plan,
+// Create a customer with a given email, and subscribe them to a plan,
 customer = await planship.createCustomer(
     {
         'email': 'vader@empire.gov'
@@ -43,12 +43,12 @@ customer = await planship.createCustomer(
     return customer
 })
 
-# Retrieve customer entitlements
+// Retrieve customer entitlements
 const customerEntitlements = await planship.getEntitlement(
     customer.id     // Customer ID
 )
 
-# Report usage for a customer
+// Report usage for a customer
 await planship.reportUsage(
     customer.id,    // Customer ID
     1,
@@ -95,7 +95,7 @@ const accessToken = await planship.getAccessToken()
 By default, the library uses the [native fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation. To use a non-default implementation of fetch, e.g. [node fetch](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch) or [SvelteKit fetch](https://kit.svelte.dev/docs/load#making-fetch-requests), simply pass it to the `Planship` constructor (last parameter).
 
 ```js
-# Client id/secret initialization
+// Client id/secret initialization
 const planship = new Planship(
     'clicker-demo',                     // Your Planship product slug
     'https://api.planship.io',          // Planship API endpoint URL
@@ -104,7 +104,7 @@ const planship = new Planship(
     myFetchApi,                         // Custom Fetch API
 )
 
-# Access token initialization
+// Access token initialization
 const planship = new Planship(
     'clicker-demo',             // Your Planship product slug
     'https://api.planship.io',  // Planship API endpoint URL

--- a/packages/fetch/docs/README.md
+++ b/packages/fetch/docs/README.md
@@ -26,10 +26,10 @@ const planship = new Planship(
     'GDSfzPD2NEM5PEzIl1JoXFRJNZm3uAhX'  // Planship API client secret
 )
 
-# List product plans
+// List product plans
 const plans = await planship.listPlans()
 
-# Create a customer with a given email, and subscribe them to a plan,
+// Create a customer with a given email, and subscribe them to a plan,
 customer = await planship.createCustomer(
     {
         'email': 'vader@empire.gov'
@@ -42,12 +42,12 @@ customer = await planship.createCustomer(
     return customer
 })
 
-# Retrieve customer entitlements
+// Retrieve customer entitlements
 const customerEntitlements = await planship.getEntitlement(
     customer.id     // Customer ID
 )
 
-# Report usage for a customer
+// Report usage for a customer
 await planship.reportUsage(
     customer.id,    // Customer ID
     1,
@@ -93,7 +93,7 @@ const accessToken = await planship.getAccessToken()
 By default, the library uses the [native fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation. To use a non-default implementation of fetch, e.g. [node fetch](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch) or [SvelteKit fetch](https://kit.svelte.dev/docs/load#making-fetch-requests), simply pass it to the `Planship` constructor (last parameter).
 
 ```js
-# Client id/secret initialization
+// Client id/secret initialization
 const planship = new Planship(
     'clicker-demo',                     // Your Planship product slug
     'https://api.planship.io',          // Planship API endpoint URL
@@ -102,7 +102,7 @@ const planship = new Planship(
     myFetchApi,                         // Custom Fetch API
 )
 
-# Access token initialization
+// Access token initialization
 const planship = new Planship(
     'clicker-demo',             // Your Planship product slug
     'https://api.planship.io',  // Planship API endpoint URL

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/fetch",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "dist/index.js",
   "author": "<pawel@planship.io>",
   "license": "MIT",

--- a/packages/fetch/src/planship/base.ts
+++ b/packages/fetch/src/planship/base.ts
@@ -107,6 +107,6 @@ export class PlanshipBase implements PlanshipBaseApi {
         'Authorization': `Basic ${btoa(this.clientId + ':' + this.clientSecret)}`
     });
 
-    return this.planshipApiInstance(AuthApi).getAccessToken({headers: headers})
+    return this.planshipApiInstance(AuthApi).getAccessToken({headers: headers, cache:'no-store'})
   }
 }


### PR DESCRIPTION
This PR, when merged, will disable caching of a Planship access token retrieved via the `getAccessToken` call in the fetch client.
Other changes include fixes to code samples in the README files.
