### PR TITLE
Fix: fetchApi constructor param not passed to base constructors in certain cases

### DIFF
--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/fetch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "author": "<pawel@planship.io>",
   "license": "MIT",

--- a/packages/fetch/src/planship/customer.ts
+++ b/packages/fetch/src/planship/customer.ts
@@ -139,6 +139,8 @@ export class PlanshipCustomer extends PlanshipProduct implements PlanshipCustome
     } else {
       if (typeof secretOrFetchApiOrWebSocketUrl === 'string') {
         webSocketUrl = secretOrFetchApiOrWebSocketUrl
+      } else {
+        secretOrFetchApi = secretOrFetchApiOrWebSocketUrl
       }
     }
 

--- a/packages/fetch/src/planship/planship.ts
+++ b/packages/fetch/src/planship/planship.ts
@@ -133,6 +133,8 @@ export class Planship extends PlanshipProduct implements PlanshipApi {
     } else {
       if (typeof secretOrFetchApiOrWebSocketUrl === 'string') {
         webSocketUrl = secretOrFetchApiOrWebSocketUrl
+      } else {
+        secretOrFetchApi = secretOrFetchApiOrWebSocketUrl
       }
     }
 


### PR DESCRIPTION
This PR, when merged, will implement a fix for a @planship/fetch Planship and PlanshipCustomer API clients problem where certain constructor overloads ignore the `fetchApi` parameter.