### PR TITLE
Reuse existing access token for new PlanshipSubscription instances created inside PlanshipCustomer

### DIFF
--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/fetch",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/index.js",
   "author": "<pawel@planship.io>",
   "license": "MIT",

--- a/packages/fetch/src/planship/customer.ts
+++ b/packages/fetch/src/planship/customer.ts
@@ -59,7 +59,7 @@ export class PlanshipCustomer extends PlanshipProduct implements PlanshipCustome
     this.customerId = customerId
 
     this.planshipSubscription = (subscriptionId: string) =>
-      new PlanshipSubscription(productSlug, customerId, subscriptionId, auth, options)
+      new PlanshipSubscription(productSlug, customerId, subscriptionId, this._getAccessToken, options)
   }
 
   public createSubscription(planSlug: string, options?: CreateSubscriptionOptions): Promise<SubscriptionWithPlan> {


### PR DESCRIPTION
This PR, when merged, will fix a problem where every new instance of the PlanshipSubscription class created inside PlanshipCustomer would initiate its own auth flow (e.g. by calling an external token getter). These instances should obtain a token from their parent (PlanshipCustomer) instead.