### PR TITLE
Fix: do not retry fetch after 401 from POST /auth/token

### DIFF
--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@planship/fetch",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "main": "dist/index.js",
   "author": "<pawel@planship.io>",

--- a/packages/fetch/src/planship/base.ts
+++ b/packages/fetch/src/planship/base.ts
@@ -69,7 +69,7 @@ export class PlanshipBase implements PlanshipBaseApi {
 
   private async onPostFetch(context: ResponseContext): Promise<Response | void> {
     this.debugLog(`onPostFetch for ${context.url}: ${context.response.status}`)
-    if (context.response.status === 401) {
+    if (context.response.status === 401 && !context.url.endsWith('/auth/token')) {
       this.debugLog(`onPostFetch 401 detected, getting a new token, retry #${this.authRetries}`)
       let authRetries = 0
       while (authRetries++ < MAX_AUTH_RETRIES) {


### PR DESCRIPTION
This PR, when merged, will prevent `@planship/fetch` from retrying a call after a 401 error is returned from `POST /auth/token` API call.